### PR TITLE
Logger printing uncessary carriage return

### DIFF
--- a/main.go
+++ b/main.go
@@ -84,7 +84,7 @@ func main() {
 					log.Errorln("Skipping CRL: ", err)
 					goto SKIP
 				} else {
-					log.Infof("CRL %s is valid, issued by %s\n", crl.Issuer.SerialNumber, crl.Issuer.CommonName)
+					log.Infof("CRL %s is valid, issued by %s", crl.Issuer.SerialNumber, crl.Issuer.CommonName)
 				}
 			}
 


### PR DESCRIPTION
Removed unecesarry carriage return from log statement.
fixes #19 