### PR TITLE
32 issue file doesn't detect empty file properly

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_TAG=v1.1.2
+ARG BUILD_TAG=v1.1.3
 
 FROM docker.io/library/golang:1.20.12-alpine3.19 as builder
 ARG BUILD_TAG

--- a/main.go
+++ b/main.go
@@ -75,6 +75,8 @@ func main() {
 			crlfile, err := os.ReadFile(tmpfile)
 			if err != nil {
 				log.Error("Problem opening downloaded file: ", err)
+				log.Info("Moving to next CRL entry.")
+				goto SKIP
 			} else {
 				crl, err := x509.ParseRevocationList(crlfile)
 				if err != nil {


### PR DESCRIPTION
- Escape loop and move to next CRL in list when download fails
- Added additional logging to indicate failure and action to skip to next CRL

closes #32 